### PR TITLE
Fix false directory name in getting started guide

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -47,13 +47,13 @@ To run an example you'll need to change to the directory where it exists as a Ru
 
 To run an example, you will need to change to the directory of the example and then use the `sinatra` command, followed by the filename.
 
-For example, to run the `hello_world.rb` example in the ``getting_started``
+For example, to run the `hello_world.rb` example in the ``getting-started``
 directory, you would need to open a Terminal and enter the following commands:
 
 1) Change to the appropriate directory using the `cd` command:
 
 ```console
-cd com1001-2024/getting_started/
+cd com1001-2024/getting-started/
 ```
 
 If you type `ls` in this directory, you'll see there is one example called `hello_world_example`, so then type:


### PR DESCRIPTION
Hi there, I am one of the first years at the UoS.

I noticed that one of the commands to copy was using an underscore for the `getting-started` directory instead of the `-` so I thought I'd submit a quick PR to fix this.

Instead of replacing the `-` with an underscore in the directory and everywhere in markdown it is referenced I thought it may just be easier to adjust the command. 

Hope this helps!